### PR TITLE
feat(dump): Automatically remove the local dump file after transfer

### DIFF
--- a/src/commands/transfer.ts
+++ b/src/commands/transfer.ts
@@ -1,10 +1,13 @@
 import { DBArgv } from '@/common/types';
 import { getDumpCommand, getRestoreCommand } from '@/common/utils';
 import { execSync } from 'child_process';
+import fs from 'fs';
 import { green, red, yellow } from 'picocolors';
 import { ArgumentsCamelCase, Argv } from 'yargs';
 
+
 import { logger } from '../logger';
+
 
 export const command = 'transfer';
 export const describe = 'Transfers database SOURCE DB to TARGET DB, stores locally first';
@@ -19,13 +22,20 @@ export function builder(yargs: Argv<DBArgv>): Argv {
     .option('source', {
       type: 'string',
       description: 'Name of the database to count its tables from TARGET VARIABLES',
-    });
+    })
+    .option('remove', {
+      alias: 'r',
+      type: 'boolean',
+      description: 'Automatically remove the local dump file after transfer',
+      default: false,
+    });   
 }
 
 export async function handler(argv: ArgumentsCamelCase<DBArgv>) {
   try {
     const sourceDb = argv.source?.toString();
     const targetDb = argv.target?.toString();
+    const removeDump = argv.remove as boolean;
 
     logger.info(yellow(`Transfering From DB from ${sourceDb} --->>> to ${targetDb}`));
 
@@ -47,6 +57,13 @@ export async function handler(argv: ArgumentsCamelCase<DBArgv>) {
       logger.info(yellow(`Restoring file ${fileName} to DB ${targetDb}!`));
       const restoreCommand = getRestoreCommand(targetDb, fileName);
       execSync(restoreCommand);
+
+      if (removeDump) {
+        logger.info(yellow(`Removing dump file ${fileName}`));
+        fs.unlinkSync(fileName);
+        logger.info(green(`Dump file ${fileName} removed successfully`));
+      }
+
       logger.info(green(`Operation is completed`));
     } else {
       logger.error(red(` No --source and --target flag is given, can not transfer`));


### PR DESCRIPTION
Summary: This pull request implements a functionality to automatically remove the local dump file after it has been successfully transferred. This enhancement aims to optimize storage usage and streamline the cleanup process in our application.

Changes Made:
Added code to handle the automatic deletion of the local dump file.

Example Usage:
"pici transfer --source=source_db --target=target_db -r" 
OR
"pici transfer --source=source_db --target=target_db --remove" 

Screenshots:
Attached are the screenshots showing the changes made in the code.
Additionally, I have included the output screenshots to demonstrate the successful execution of the new functionality.

![Ekran görüntüsü 2024-09-27 222144](https://github.com/user-attachments/assets/2abd97cd-4c9f-44a7-a487-32439cf18f7b)

![Ekran görüntüsü 2024-09-27 222247](https://github.com/user-attachments/assets/aa61e164-3756-4f6d-b227-8afa01da979d)

![Ekran görüntüsü 2024-09-27 222310](https://github.com/user-attachments/assets/3833aea4-5aa2-4165-a274-da13f306e2f9)

Testing:
The new feature has been tested and verified to function correctly without any issues.
